### PR TITLE
pyrah: Return byte object form rah_read

### DIFF
--- a/pyrah/__init__.py
+++ b/pyrah/__init__.py
@@ -48,4 +48,4 @@ def rah_read(appid, d_len):
     __rah.rah_read.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_ulong]
 
     __rah.rah_read(appid, ptr, d_len)
-    return repr(ptr.raw)
+    return ptr.raw


### PR DESCRIPTION

The data returned was in a `b""` string format, with `<class 'str'>`.
The type should be of `<class' bytes'>` for a `Byte string`.

**Reason:** 
`repr()` function returns a printable representation of the object by converting that object to a string.

Thus return byte object for uniformity.